### PR TITLE
Add example servers for each provider

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# UTCP Example Servers
+
+Small standalone servers demonstrating transports supported by the `rb-utcp` library.
+Each script binds to `127.0.0.1` on a random available port and prints its URL on startup.
+
+Run examples with Ruby:
+
+```
+ruby examples/http_server.rb
+ruby examples/websocket_server.rb
+ruby examples/graphql_server.rb
+ruby examples/tcp_echo_server.rb
+ruby examples/udp_echo_server.rb
+ruby examples/mcp_server.rb
+```
+
+These servers are intentionally minimal and do not perform any authentication.
+They are meant for local experimentation with the corresponding UTCP providers.

--- a/examples/graphql_server.rb
+++ b/examples/graphql_server.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Minimal GraphQL HTTP server for the UTCP GraphQL provider.
+# It ignores the query and simply returns a greeting using variables.
+# Run with:
+#   ruby examples/graphql_server.rb
+
+require 'webrick'
+require 'json'
+
+class GraphQLServlet < WEBrick::HTTPServlet::AbstractServlet
+  def do_POST(req, res)
+    data = JSON.parse(req.body) rescue {}
+    name = data.dig('variables', 'name') || 'world'
+    res['Content-Type'] = 'application/json'
+    res.body = JSON.dump({ 'data' => { 'greeting' => "hello #{name}" } })
+  end
+end
+
+server = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1', AccessLog: [], Logger: WEBrick::Log.new($stderr, WEBrick::Log::ERROR))
+server.mount '/graphql', GraphQLServlet
+port = server.config[:Port]
+puts "GraphQL example listening at http://127.0.0.1:#{port}/graphql"
+trap('INT') { server.shutdown }
+server.start

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Minimal HTTP server demonstrating UTCP HTTP, HTTP stream and SSE providers.
+# Run with:
+#   ruby examples/http_server.rb
+# The server prints its base URL on startup and exposes the following endpoints:
+#   /manual - UTCP manual with tool definitions
+#   /call   - echo tool using HTTP POST
+#   /stream - emits JSON chunks
+#   /sse    - emits Server-Sent Events
+
+require 'webrick'
+require 'json'
+
+manual = {
+  'version' => '1.0',
+  'tools' => [
+    {
+      'name' => 'echo',
+      'description' => 'echo arguments',
+      'inputs' => { 'type' => 'object' },
+      'outputs' => { 'type' => 'object' },
+      'tool_provider' => {
+        'provider_type' => 'http',
+        'url' => nil, # filled after server starts
+        'http_method' => 'POST',
+        'content_type' => 'application/json'
+      }
+    },
+    {
+      'name' => 'stream',
+      'description' => 'chunked stream',
+      'inputs' => { 'type' => 'object' },
+      'outputs' => { 'type' => 'string' },
+      'tool_provider' => {
+        'provider_type' => 'http_stream',
+        'url' => nil
+      }
+    },
+    {
+      'name' => 'sse',
+      'description' => 'server sent events',
+      'inputs' => { 'type' => 'object' },
+      'outputs' => { 'type' => 'string' },
+      'tool_provider' => {
+        'provider_type' => 'sse',
+        'url' => nil
+      }
+    }
+  ]
+}
+
+server = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1', AccessLog: [], Logger: WEBrick::Log.new($stderr, WEBrick::Log::ERROR))
+port = server.config[:Port]
+base = "http://127.0.0.1:#{port}"
+manual['tools'][0]['tool_provider']['url'] = base + '/call'
+manual['tools'][1]['tool_provider']['url'] = base + '/stream'
+manual['tools'][2]['tool_provider']['url'] = base + '/sse'
+
+server.mount_proc '/manual' do |_req, res|
+  res['Content-Type'] = 'application/json'
+  res.body = JSON.dump(manual)
+end
+
+server.mount_proc '/call' do |req, res|
+  data = JSON.parse(req.body) rescue {}
+  res['Content-Type'] = 'application/json'
+  res.body = JSON.dump({ 'ok' => true, 'echo' => data })
+end
+
+server.mount_proc '/stream' do |_req, res|
+  res['Content-Type'] = 'application/json'
+  res.chunked = true
+  res.body = Enumerator.new do |y|
+    [{ 'a' => 1 }, { 'b' => 2 }, { 'c' => 3 }].each do |obj|
+      y << JSON.dump(obj)
+      sleep 0.2
+    end
+  end
+end
+
+server.mount_proc '/sse' do |_req, res|
+  res['Content-Type'] = 'text/event-stream'
+  res.chunked = true
+  res.body = Enumerator.new do |y|
+    3.times do |i|
+      y << "data: event-#{i}\n\n"
+      sleep 0.2
+    end
+  end
+end
+
+trap('INT') { server.shutdown }
+puts "HTTP provider example listening at #{base}"
+puts "Manual: #{base}/manual"
+server.start

--- a/examples/mcp_server.rb
+++ b/examples/mcp_server.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Minimal MCP server for the UTCP MCP provider.
+# Run with:
+#   ruby examples/mcp_server.rb
+
+require 'webrick'
+require 'json'
+
+manual = {
+  'version' => '1.0',
+  'tools' => [
+    {
+      'name' => 'hello',
+      'description' => 'say hello',
+      'inputs' => { 'type' => 'object' },
+      'outputs' => { 'type' => 'object' },
+      'tool_provider' => {
+        'provider_type' => 'mcp',
+        'url' => nil, # filled with server base
+        'call_path' => '/call'
+      }
+    }
+  ]
+}
+
+server = WEBrick::HTTPServer.new(Port: 0, BindAddress: '127.0.0.1', AccessLog: [], Logger: WEBrick::Log.new($stderr, WEBrick::Log::ERROR))
+port = server.config[:Port]
+base = "http://127.0.0.1:#{port}"
+manual['tools'][0]['tool_provider']['url'] = base
+
+server.mount_proc '/manual' do |_req, res|
+  res['Content-Type'] = 'application/json'
+  res.body = JSON.dump(manual)
+end
+
+server.mount_proc '/call' do |req, res|
+  data = JSON.parse(req.body) rescue {}
+  name = data.dig('arguments', 'name')
+  out = { 'tool' => data['tool'], 'arguments' => data['arguments'], 'greeting' => "hello #{name}" }
+  res['Content-Type'] = 'application/json'
+  res.body = JSON.dump(out)
+end
+
+trap('INT') { server.shutdown }
+puts "MCP provider example listening at #{base}"
+puts "Discovery: #{base}/manual"
+server.start

--- a/examples/tcp_echo_server.rb
+++ b/examples/tcp_echo_server.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Simple TCP echo server for the UTCP TCP provider.
+# Run with:
+#   ruby examples/tcp_echo_server.rb
+
+require 'socket'
+
+server = TCPServer.new('127.0.0.1', 0)
+port = server.addr[1]
+puts "TCP echo server listening on 127.0.0.1:#{port}"
+trap('INT') { server.close; exit }
+
+loop do
+  sock = server.accept
+  Thread.new(sock) do |s|
+    begin
+      while (line = s.gets)
+        s.write(line)
+      end
+    ensure
+      s.close
+    end
+  end
+end

--- a/examples/udp_echo_server.rb
+++ b/examples/udp_echo_server.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Simple UDP echo server for the UTCP UDP provider.
+# Run with:
+#   ruby examples/udp_echo_server.rb
+
+require 'socket'
+
+sock = UDPSocket.new
+sock.bind('127.0.0.1', 0)
+port = sock.addr[1]
+puts "UDP echo server listening on 127.0.0.1:#{port}"
+trap('INT') { sock.close; exit }
+
+loop do
+  data, addr = sock.recvfrom(2048)
+  sock.send(data, 0, addr[3], addr[1])
+end

--- a/examples/websocket_server.rb
+++ b/examples/websocket_server.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Minimal WebSocket echo server for the UTCP WebSocket provider.
+# Run with:
+#   ruby examples/websocket_server.rb
+# The server prints its ws:// URL and echoes the first text frame it receives.
+
+require 'socket'
+require 'digest/sha1'
+require 'base64'
+
+GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+server = TCPServer.new('127.0.0.1', 0)
+port = server.addr[1]
+puts "WebSocket example listening at ws://127.0.0.1:#{port}/"
+trap('INT') { server.close; exit }
+
+loop do
+  sock = server.accept
+  Thread.new(sock) do |s|
+    # Read HTTP handshake
+    request = ""
+    while (line = s.gets)
+      request << line
+      break if line == "\r\n"
+    end
+    key = request[/Sec-WebSocket-Key: (.*)\r\n/, 1]
+    accept = Base64.strict_encode64(Digest::SHA1.digest(key + GUID))
+    headers = [
+      'HTTP/1.1 101 Switching Protocols',
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      "Sec-WebSocket-Accept: #{accept}",
+      '', ''
+    ].join("\r\n")
+    s.write(headers)
+
+    # Read one text frame from client
+    h = s.read(2)&.bytes
+    next unless h
+    b1, b2 = h
+    len = b2 & 0x7f
+    len = s.read(2).unpack('n')[0] if len == 126
+    len = s.read(8).unpack('Q>')[0] if len == 127
+    mask = s.read(4)
+    payload = s.read(len) || ''
+    data = payload.bytes.each_with_index.map { |b, i| (b ^ mask.getbyte(i % 4)) }.pack('C*')
+
+    # Echo back
+    msg = "echo: #{data}"
+    frame = [0x81].pack('C') # FIN + text
+    if msg.bytesize < 126
+      frame << msg.bytesize.chr
+    elsif msg.bytesize < 65_536
+      frame << [126, msg.bytesize].pack('Cn')
+    else
+      frame << [127, msg.bytesize].pack('CQ>')
+    end
+    s.write(frame + msg)
+    s.close
+  end
+end


### PR DESCRIPTION
## Summary
- Provide standalone HTTP example covering manual discovery, chunked streams, and SSE
- Add WebSocket, GraphQL, TCP, UDP, and MCP server examples
- Document running the example servers

## Testing
- `ruby -Ilib:test test/*_test.rb`


------
https://chatgpt.com/codex/tasks/task_e_689cc689067c83228f8b5b8bfdf0e4f0